### PR TITLE
Fix delete condition of short diff

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -97,7 +97,7 @@ const formatDetails = (diffs: Diff[], o: CommentOptions): string => {
 
 const formatShortDetails = (diffs: Diff[], o: CommentOptions): string => {
   const lines = diffs.flatMap((d) => {
-    if (d.headRelativePath && d.baseRelativePath === undefined) {
+    if (d.headRelativePath === undefined && d.baseRelativePath !== undefined) {
       return [`### ${d.headRelativePath} (deleted)`]
     }
     const lines = []


### PR DESCRIPTION
Currently, the short diff shows "(deleted)" even if no deletion.