### PR TITLE
Post no diff comment and change default strategy to replace

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -39,7 +39,6 @@ jobs:
           base: tests/fixtures/base
           head: tests/fixtures/head
           label: changed
-          update-if-exists: replace
       - run: test ${{ steps.diff.outputs.different }} = true
 
       - name: e2e-test (no-diff)
@@ -49,7 +48,6 @@ jobs:
           base: tests/fixtures/head
           head: tests/fixtures/head
           label: changed
-          update-if-exists: replace
       - run: test ${{ steps.no-diff.outputs.different }} = false
 
   generate:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an action to compute a diff between head and base, and post it to a comm
 
 ## Getting Started
 
-To compute the diff between `old-directory` and `new-directory`:
+To post a comment of the diff between `old-directory` and `new-directory`,
 
 ```yaml
 - uses: int128/diff-action@v1
@@ -12,6 +12,8 @@ To compute the diff between `old-directory` and `new-directory`:
     base: old-directory
     head: new-directory
 ```
+
+If no difference, it post a comment of "No diff".
 
 ### Show diff of generated manifests
 
@@ -65,42 +67,18 @@ To add label(s) if there is difference or remove it if not:
     label: manifest-changed
 ```
 
-### Update the comment if exists
+### Comment strategy
 
-You can create or update the comment if exists.
-It is useful to avoid too many comments in an issue.
+This action supports the following strategies:
 
-To replace the comment if it exists,
+- `create`: Create a new comment.
+- `replace`: Replace the body of existing comment if exists. (default)
+- `append`: Append the diff to the existing comment if exists.
+- `recreate`: Delete the existing comment and create a new one.
 
-```yaml
-- uses: int128/diff-action@v1
-  with:
-    base: ${{ steps.kustomize-base.outputs.directory }}
-    head: ${{ steps.kustomize-head.outputs.directory }}
-    update-if-exists: replace
-```
+You can change the strategy by `update-if-exists`.
 
-To append the comment if it exists,
-
-```yaml
-- uses: int128/diff-action@v1
-  with:
-    base: ${{ steps.kustomize-base.outputs.directory }}
-    head: ${{ steps.kustomize-head.outputs.directory }}
-    update-if-exists: append
-```
-
-To recreate the comment if it exists,
-
-```yaml
-- uses: int128/diff-action@v1
-  with:
-    base: ${{ steps.kustomize-base.outputs.directory }}
-    head: ${{ steps.kustomize-head.outputs.directory }}
-    update-if-exists: recreate
-```
-
-By default, this action identifies the existing comment by a key of workflow name and job name.
+This action identifies the existing comment by both workflow name and job name.
 You can set a custom key to `update-if-exists-key`.
 
 ## Specification
@@ -109,16 +87,16 @@ This action posts a comment on `pull_request` or `pull_request_target` event onl
 
 ### Inputs
 
-| Name                   | Required                                   | Description                                                                               |
-| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| `base`                 | (required)                                 | Path(s) of base (multiline)                                                               |
-| `head`                 | (required)                                 | Path(s) of head (multiline)                                                               |
-| `label`                | -                                          | Label(s) to add or remove to indicate the diff (multiline)                                |
-| `comment-header`       | -                                          | Header of a comment to post                                                               |
-| `comment-footer`       | -                                          | Footer of a comment to post                                                               |
-| `update-if-exists`     | (optional)                                 | If set, create or update a comment. This must be either `replace`, `append` or `recreate` |
-| `update-if-exists-key` | `${{ github.workflow }}/${{ github.job }}` | Key for `update-if-exists`                                                                |
-| `token`                | `github.token`                             | GitHub token to post a comment                                                            |
+| Name                   | Required                                   | Description                                                |
+| ---------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `base`                 | (required)                                 | Path(s) of base (multiline)                                |
+| `head`                 | (required)                                 | Path(s) of head (multiline)                                |
+| `label`                | -                                          | Label(s) to add or remove to indicate the diff (multiline) |
+| `comment-header`       | -                                          | Header of a comment to post                                |
+| `comment-footer`       | -                                          | Footer of a comment to post                                |
+| `update-if-exists`     | (optional)                                 | Either `create`, `replace`, `append` or `recreate`         |
+| `update-if-exists-key` | `${{ github.workflow }}/${{ github.job }}` | Key for `update-if-exists`                                 |
+| `token`                | `github.token`                             | GitHub token to post a comment                             |
 
 ### Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,8 +22,9 @@ inputs:
       [See the workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
       <!-- diff-action -->
   update-if-exists:
-    description: If set, create or update a comment. This must be either replace, append or recreate
-    required: false
+    description: Either create, replace, append or recreate
+    required: true
+    default: replace
   update-if-exists-key:
     description: Key for update-if-exists, appended into a comment
     required: true

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -7,7 +7,7 @@ type Comment = {
   updateIfExistsKey: string
 }
 
-export type UpdateIfExistsType = 'replace' | 'append' | 'recreate' | undefined
+export type UpdateIfExistsType = 'create' | 'replace' | 'append' | 'recreate'
 
 export const addComment = async (github: GitHubContext, comment: Comment): Promise<void> => {
   if (!github.issueNumber) {
@@ -15,7 +15,7 @@ export const addComment = async (github: GitHubContext, comment: Comment): Promi
     return
   }
 
-  if (comment.updateIfExists === undefined) {
+  if (comment.updateIfExists === 'create') {
     core.info(`Creating a comment to #${github.issueNumber}`)
     const { data: created } = await github.octokit.rest.issues.createComment({
       owner: github.owner,

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,6 +8,10 @@ type CommentOptions = {
 }
 
 export const formatComment = (diffs: Diff[], o: CommentOptions): string => {
+  if (diffs.length === 0) {
+    return generateNoDiffComment(o)
+  }
+
   // Comment body must be less than 64kB
   // https://github.community/t/maximum-length-for-the-comment-body-in-issues-and-pr/148867
   const fullComment = generateFullComment(diffs, o)
@@ -27,6 +31,13 @@ export const formatComment = (diffs: Diff[], o: CommentOptions): string => {
   core.info(`Fallback to last resort, because summary comment is too long (${summaryComment.length} chars)`)
   return `${o.header}\nSee the full diff from ${o.workflowRunURL}\n${o.footer}`
 }
+
+const generateNoDiffComment = (o: CommentOptions): string => `\
+${o.header}
+
+No diff
+
+${o.footer}`
 
 const generateFullComment = (diffs: Diff[], o: CommentOptions): string => `\
 ${o.header}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,10 +17,7 @@ const main = async (): Promise<void> => {
 }
 
 const updateIfExistsValue = (s: string): UpdateIfExistsType => {
-  if (!s) {
-    return undefined
-  }
-  if (s !== 'replace' && s !== 'append' && s !== 'recreate') {
+  if (s !== 'create' && s !== 'replace' && s !== 'append' && s !== 'recreate') {
     throw new Error(`update-if-exists must be replace or recreate: ${s}`)
   }
   return s

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ const main = async (): Promise<void> => {
     updateIfExists: updateIfExistsValue(core.getInput('update-if-exists')),
     updateIfExistsKey: core.getInput('update-if-exists-key'),
   })
+  core.info(`Setting the outputs to ${JSON.stringify(outputs)}`)
   core.setOutput('different', outputs.different)
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,13 +25,6 @@ export const run = async (github: GitHubContext, inputs: Inputs): Promise<Output
   core.endGroup()
 
   const diffs = await computeDiff(inputs.base, inputs.head)
-
-  if (diffs.length === 0) {
-    core.info('No diff')
-    await removeLabels(github, inputs.label)
-    return { different: false }
-  }
-
   const body = formatComment(diffs, {
     header: inputs.commentHeader,
     footer: inputs.commentFooter,
@@ -42,6 +35,12 @@ export const run = async (github: GitHubContext, inputs: Inputs): Promise<Output
     updateIfExists: inputs.updateIfExists,
     updateIfExistsKey: inputs.updateIfExistsKey,
   })
-  await addLabels(github, inputs.label)
-  return { different: true }
+
+  if (diffs.length > 0) {
+    await addLabels(github, inputs.label)
+  } else {
+    await removeLabels(github, inputs.label)
+  }
+
+  return { different: diffs.length > 0 }
 }


### PR DESCRIPTION
## Problem to solve
Currently, this action does not post a comment if no diff. A reviewer needs to see the workflow log to check if the pull request causes no diff.

## How to solve
Change the behavior as follows:

- Even if no diff, post a comment.
- Change the default comment strategy to "replace". This prevents the comment flood.
